### PR TITLE
more diamond perf examples

### DIFF
--- a/performance-tests/tests/computedDiamondUpdates/computedDiamond1000UpdatesWith1000Dependencies.js
+++ b/performance-tests/tests/computedDiamondUpdates/computedDiamond1000UpdatesWith1000Dependencies.js
@@ -1,0 +1,3 @@
+var computedDiamondUpdate = require('../../scenarios/computedDiamondUpdate');
+
+module.exports = computedDiamondUpdate(1000, 1000);

--- a/performance-tests/tests/computedDiamondUpdates/computedDiamond1000UpdatesWith100Dependencies.js
+++ b/performance-tests/tests/computedDiamondUpdates/computedDiamond1000UpdatesWith100Dependencies.js
@@ -1,0 +1,3 @@
+var computedDiamondUpdate = require('../../scenarios/computedDiamondUpdate');
+
+module.exports = computedDiamondUpdate(1000, 100);


### PR DESCRIPTION
Performance is not stable yet and it somehow depends on the count of hidden dependencies, but should not..

```
 Starting 'performance-scenario-computedDiamondUpdates'...
   Running 'computed diamond updated 1000 times with 100 hidden dependencies'
     knockout x 77.96 ops/sec +4.29% (68 runs sampled)
     itDepends x 174 ops/sec +2.44% (80 runs sampled)
   'computed diamond updated 1000 times with 100 hidden dependencies'
     Passed:
       'itDepends' at 2.23x faster
       'knockout' is etalon
   Running 'computed diamond updated 1000 times with 500 hidden dependencies'
     knockout x 73.21 ops/sec +4.21% (60 runs sampled)
     itDepends x 61.71 ops/sec +3.92% (60 runs sampled)
   'computed diamond updated 1000 times with 500 hidden dependencies'
     Passed:
       'knockout' is etalon
       'itDepends' at 1.19x slower
   Running 'computed diamond updated 1000 times with 1000 hidden dependencies'
     knockout x 65.33 ops/sec +9.96% (53 runs sampled)
     itDepends x 36.58 ops/sec +3.42% (45 runs sampled)
   'computed diamond updated 1000 times with 1000 hidden dependencies'
     Passed:
       'knockout' is etalon
       'itDepends' at 1.79x slower
```
