### PR TITLE
simpler tracking

### DIFF
--- a/src/tracking.ts
+++ b/src/tracking.ts
@@ -2,7 +2,6 @@
 
 export type Tracker = (id: number, observableValue: any, currentValue: any) => void;
 var activeTracker: Tracker;
-var trackers: Tracker[] = [];
 var nextObservableId = 0;
 
 export var lastWriteVersion = 0;
@@ -16,21 +15,13 @@ export function takeNextObservableId(): number {
     return ++nextObservableId;
 }
 
-export interface ITrackerExecution {
-    execute<T>(action: () => T): T;
-}
+export function executeWithTracker<T>(action: () => T, tracker?: Tracker): T {
+    var currentTracker = activeTracker;
+    activeTracker = tracker;
 
-export function trackingWith(tracker: Tracker): ITrackerExecution {
-    return {
-        execute: function<T>(action: () => T): T {
-            trackers.push(activeTracker);
-            activeTracker = tracker;
-
-            try {
-                return action();
-            } finally {
-                activeTracker = trackers.pop();
-            }
-        }
-    };
+    try {
+        return action();
+    } finally {
+        activeTracker = currentTracker;
+    }
 }


### PR DESCRIPTION
Improves performance.
Before:

```
D:\it-depends>gulp performance-scenario-computedDiamondUpdates
[14:27:39] Using gulpfile D:\it-depends\gulpfile.js
[14:27:39] Starting 'performance-scenario-computedDiamondUpdates'...
[14:27:39]   Running 'computed diamond updated 1000 times with 1000 hidden dependencies' f
[14:27:44]     knockout x 65.33 ops/sec +9.96% (53 runs sampled)
[14:27:51]     itDepends x 36.58 ops/sec +3.42% (45 runs sampled)
[14:27:51]   'computed diamond updated 1000 times with 1000 hidden dependencies' from D:\i
[14:27:51]     Passed:
[14:27:51]       'knockout' is etalon
[14:27:51]       'itDepends' at 1.79x slower
[14:27:51]   Running 'computed diamond updated 1000 times with 100 hidden dependencies' fr
[14:27:56]     knockout x 77.96 ops/sec +4.29% (68 runs sampled)
[14:28:02]     itDepends x 174 ops/sec +2.44% (80 runs sampled)
[14:28:02]   'computed diamond updated 1000 times with 100 hidden dependencies' from D:\it
[14:28:02]     Passed:
[14:28:02]       'itDepends' at 2.23x faster
[14:28:02]       'knockout' is etalon
[14:28:02]   Running 'computed diamond updated 1000 times with 500 hidden dependencies' fr
[14:28:08]     knockout x 73.21 ops/sec +4.21% (60 runs sampled)
[14:28:13]     itDepends x 61.71 ops/sec +3.92% (60 runs sampled)
[14:28:13]   'computed diamond updated 1000 times with 500 hidden dependencies' from D:\it
[14:28:13]     Passed:
[14:28:13]       'knockout' is etalon
[14:28:13]       'itDepends' at 1.19x slower
[14:28:13] Finished 'performance-scenario-computedDiamondUpdates' after 35 s

```

after:

```
D:\it-depends>gulp performance-scenario-computedDiamondUpdates
[17:50:53] Using gulpfile D:\it-depends\gulpfile.js
[17:50:53] Starting 'performance-scenario-computedDiamondUpdates'...
[17:50:53]   Running 'computed diamond updated 1000 times with 1000 hidden dependencies' f
[17:50:59]     knockout x 52.87 ops/sec +8.99% (50 runs sampled)
[17:51:05]     itDepends x 36.37 ops/sec +4.71% (44 runs sampled)
[17:51:05]   'computed diamond updated 1000 times with 1000 hidden dependencies' from D:\i
[17:51:05]     Passed:
[17:51:05]       'knockout' is etalon
[17:51:05]       'itDepends' at 1.45x slower
[17:51:05]   Running 'computed diamond updated 1000 times with 100 hidden dependencies' fr
[17:51:10]     knockout x 67.66 ops/sec +3.10% (67 runs sampled)
[17:51:16]     itDepends x 180 ops/sec +2.61% (76 runs sampled)
[17:51:16]   'computed diamond updated 1000 times with 100 hidden dependencies' from D:\it
[17:51:16]     Passed:
[17:51:16]       'itDepends' at 2.66x faster
[17:51:16]       'knockout' is etalon
[17:51:16]   Running 'computed diamond updated 1000 times with 500 hidden dependencies' fr
[17:51:22]     knockout x 60.56 ops/sec +4.63% (60 runs sampled)
[17:51:28]     itDepends x 63.46 ops/sec +4.49% (61 runs sampled)
[17:51:28]   'computed diamond updated 1000 times with 500 hidden dependencies' from D:\it
[17:51:28]     Passed:
[17:51:28]       'itDepends' at 1.05x faster
[17:51:28]       'knockout' is etalon
[17:51:28] Finished 'performance-scenario-computedDiamondUpdates' after 35 s
```
